### PR TITLE
Support custom CA certificates

### DIFF
--- a/src/docker/start.sh
+++ b/src/docker/start.sh
@@ -70,5 +70,15 @@ sed -i "s|{nngm-mainzelliste-url}|${NNGM_MAINZELLISTE_URL}|"                "$fi
 
 export CATALINA_OPTS="${CATALINA_OPTS} -javaagent:/docker/jmx_prometheus_javaagent-0.3.1.jar=9100:/docker/jmx-exporter.yml"
 
+# SSL Certs
+if [ -d "/custom-certs" ]; then
+	echo "Found custom-certs. Starting import of certs:"
+	for file in /custom-certs/*; do
+		cp -v $file /usr/local/share/ca-certificates/$(basename $file).crt
+	done
+	update-ca-certificates || (echo -e "\nThe system has REJECTED one of the certificates:"; ls -l /custom-certs/*; echo "Make sure that ALL of the certificates are valid."; exit 1)
+	echo "Successfully imported custom-certs."
+fi
+
 # Replace start.sh with catalina.sh
 exec /usr/local/tomcat/bin/catalina.sh run


### PR DESCRIPTION
**What's in the PR**
* On each startup, the Docker container will import custom CA certificates found in `/custom-certs`.
* Certs are imported using the way recommended in the Debian universe since that's the base of our Tomcat image.
* In case of any invalid certificates, Container will FAIL EARLY on startup.

**How to test manually**
* Create test CA cert with `openssl genrsa -aes256 -out ca-key.pem 2048` and `openssl req -x509 -new -nodes -extensions v3_ca -key ca-key.pem -days 1024 -out ca-root.pem -sha512`.
* Run container with volume mount to `/custom-certs/`.
* Observe the certs getting imported right before Tomcat starts.

**TODO**
* Would be great if someone could update the documentation for the sites, then update this branch & PR.