### PR TITLE
Ensure that the dockerimage uses log4j configuration from src/docker/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ ENV JMX_EXPORTER_VERSION 0.3.1
 COPY src/docker/jmx-exporter.yml                /docker/jmx-exporter.yml
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar /docker/
 
+ENV JAVA_OPTS "-Dlog4j.configurationFile=${CATALINA_HOME}/conf/log4j2.xml"
 ADD src/docker/start.sh                         /docker/
 RUN chmod +x                                    /docker/start.sh
 CMD ["sh", "-c", "/docker/start.sh"]


### PR DESCRIPTION
*Note: Recreated [PR30](https://github.com/samply/share-client/pull/30). It's build failed because the branch was on a fork* 
**What's in the PR**

- Added environment variable JAVA_OPTS="-Dlog4j.configurationFile=${CATALINA_HOME}/conf/log4j2.xml" to the image. Without this, log4j will use the wrong configuration file which will result in the LOG_LEVEL environment variable not working.

**How to test manually**

- Run the current samply/share-client:dktk-develop image from Dockerhub. If you now run "docker exec ls" you will see 2 files which shouldn't be there:
- ${logDirLinux}${fileBaseName}${fileNameSuffix}
- ${logDirWindows}${fileBaseName}${fileNameSuffix}
- Repeat the same with the image torbrenner/share-client:dktk-ContainerLogging build from my fork. The two files shouldn't exist