### PR TITLE
bugfix: configuration timings

### DIFF
--- a/src/main/resources/db/migration/V030__dktk_export_timing_configuration_bugfix.sql
+++ b/src/main/resources/db/migration/V030__dktk_export_timing_configuration_bugfix.sql
@@ -1,0 +1,3 @@
+UPDATE samply.configuration_timings SET setting='180' WHERE name='JOB_CHECK_INQUIRY_STATUS_RESULTS_RETRY_ATTEMPTS';
+UPDATE samply.configuration_timings SET setting='30' WHERE name='JOB_CHECK_INQUIRY_STATUS_STATS_RETRY_INTERVAL_SECONDS';
+UPDATE samply.configuration_timings SET setting='20' WHERE name='JOB_CHECK_INQUIRY_STATUS_STATS_RETRY_ATTEMPTS';


### PR DESCRIPTION
**What's in the PR**
* Bugfix: Write configuration Timing values of V029__dktk_export_timing_configuration.sql in right table 
