### PR TITLE
Add ARM64 to Docker Image Build Platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             PROJECT=${{matrix.project_context}}
           push: true


### PR DESCRIPTION
I need this for my M1 Mac.