### PR TITLE
Add war files to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Upload binaries to release
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' }}
+        if: ${{ github.tag != '' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Upload binaries to release
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,12 @@ jobs:
         uses: github/codeql-action/upload-sarif@codeql-bundle-20211208
         with:
           sarif_file: trivy-results.sarif
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/connector.war
+          asset_name: ${{matrix.project_context}}_connector.war
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/connector.war
-          asset_name: ${{matrix.project_context}}_connector.war
+          asset_name: ${{matrix.project_context}}_connector_${{ github.tag }}.war
           tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
**What's in the PR**
With this addition to the ci.yaml the build wars will be publish automatically to the release tap of the github page.