### PR TITLE
gefixt: fixed: If a bundle already contains identifiers, the URL will…

### DIFF
--- a/src/main/java/de/samply/share/client/util/connector/MainzellisteConnector.java
+++ b/src/main/java/de/samply/share/client/util/connector/MainzellisteConnector.java
@@ -330,12 +330,7 @@ public class MainzellisteConnector {
     patientNew.setMeta(meta);
     List<Identifier> identifierList = new ArrayList<>();
     Identifier identifier = new Identifier();
-    String identifierSystem = originalPatient.getIdentifierFirstRep().getSystem();
-    if (identifierSystem != null) {
-      identifier.setSystem(identifierSystem);
-    } else {
-      identifier.setSystem(PATIENT_IDENTIFIER_SYSTEM);
-    }
+    identifier.setSystem(PATIENT_IDENTIFIER_SYSTEM);
     identifierList.add(identifier);
     patientNew.setIdentifier(identifierList);
     return patientNew;


### PR DESCRIPTION
**Issue**: if an identifier is already in the bundle, the original URL will be taken over, which leads to a rejection of the data set in the EDC system. 
**Solution**: the URL of the identifier will always be replaced.